### PR TITLE
Remove console logging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class Aqara extends events.EventEmitter {
       }
     }
 
-    if (!handled) console.log(`not handled: ${JSON.stringify(parsed)}`)
+    if (!handled) this.emit('unhandled', parsed)
   }
 }
 


### PR DESCRIPTION
One should be able to not handle certain events without clogging up the console of library users.